### PR TITLE
feat: Create AutoAnnouncer plugin for PaperMC

### DIFF
--- a/src/main/java/com/example/autoannouncer/AnnouncementTask.java
+++ b/src/main/java/com/example/autoannouncer/AnnouncementTask.java
@@ -1,0 +1,36 @@
+package com.example.autoannouncer;
+
+import org.bukkit.scheduler.BukkitRunnable;
+import java.util.List;
+
+public class AnnouncementTask extends BukkitRunnable {
+
+    private final AutoAnnouncer plugin;
+    private final List<String> messages;
+    private int messageIndex = 0;
+
+    public AnnouncementTask(AutoAnnouncer plugin, List<String> messages) {
+        this.plugin = plugin;
+        this.messages = messages;
+    }
+
+    @Override
+    public void run() {
+        // Ensure the message list is not empty to avoid errors
+        if (messages.isEmpty()) {
+            return;
+        }
+
+        // Get the current message
+        String message = messages.get(messageIndex);
+
+        // Broadcast the colorized message
+        plugin.getServer().broadcastMessage(AutoAnnouncer.colorize(message));
+
+        // Move to the next message for the next execution
+        messageIndex++;
+        if (messageIndex >= messages.size()) {
+            messageIndex = 0; // Reset to the start
+        }
+    }
+}

--- a/src/main/java/com/example/autoannouncer/AutoAnnouncer.java
+++ b/src/main/java/com/example/autoannouncer/AutoAnnouncer.java
@@ -1,0 +1,53 @@
+package com.example.autoannouncer;
+
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.ChatColor;
+import java.util.List;
+
+public class AutoAnnouncer extends JavaPlugin {
+
+    private BukkitTask announcementTask;
+
+    @Override
+    public void onEnable() {
+        // Save the default config.yml from the JAR if it doesn't exist
+        saveDefaultConfig();
+
+        // Load configuration
+        int interval = getConfig().getInt("interval", 60);
+        List<String> messages = getConfig().getStringList("messages");
+
+        // Basic validation
+        if (messages.isEmpty()) {
+            getLogger().warning("No messages found in config.yml. The announcer will not start.");
+            return;
+        }
+
+        if (interval <= 0) {
+            getLogger().warning("The announcement interval must be positive. The announcer will not start.");
+            return;
+        }
+
+        // Schedule the announcement task
+        // The period is in ticks (20 ticks = 1 second)
+        long period = interval * 20L;
+        announcementTask = new AnnouncementTask(this, messages).runTaskTimer(this, 0L, period);
+
+        getLogger().info("AutoAnnouncer has been enabled with " + messages.size() + " messages, running every " + interval + " seconds.");
+    }
+
+    @Override
+    public void onDisable() {
+        // Cancel the task when the plugin is disabled
+        if (announcementTask != null && !announcementTask.isCancelled()) {
+            announcementTask.cancel();
+        }
+        getLogger().info("AutoAnnouncer has been disabled.");
+    }
+
+    // Helper method to translate color codes
+    public static String colorize(String message) {
+        return ChatColor.translateAlternateColorCodes('&', message);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,12 @@
+# Configuration for AutoAnnouncer
+
+# The interval in seconds between each announcement.
+interval: 60
+
+# The list of messages to be broadcast.
+# You can add as many messages as you want.
+# Color codes using '&' are supported.
+messages:
+  - "&aWelcome to our server! We hope you have a great time."
+  - "&bMake sure to read the /rules."
+  - "&eDid you know you can vote for our server to get rewards? Use /vote!"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,5 @@
+name: AutoAnnouncer
+version: 1.0.0
+main: com.example.autoannouncer.AutoAnnouncer
+api-version: 1.18
+description: A simple plugin to automatically broadcast messages.


### PR DESCRIPTION
This commit introduces a new plugin, AutoAnnouncer, for PaperMC and other Spigot-based servers.

The plugin periodically broadcasts a configurable list of messages to all players on the server. The interval between messages and the messages themselves can be customized in the `config.yml` file.

Features:
- Configurable announcement interval (in seconds).
- Configurable list of messages.
- Support for chat color codes using the '&' character.
- Graceful startup and shutdown, with logging to the server console.
- Follows modern plugin development practices using `BukkitRunnable`.