### PR TITLE
feat: Add hex color and prefix support

### DIFF
--- a/src/main/java/com/example/autoannouncer/AnnouncementTask.java
+++ b/src/main/java/com/example/autoannouncer/AnnouncementTask.java
@@ -6,11 +6,13 @@ import java.util.List;
 public class AnnouncementTask extends BukkitRunnable {
 
     private final AutoAnnouncer plugin;
+    private final String prefix;
     private final List<String> messages;
     private int messageIndex = 0;
 
-    public AnnouncementTask(AutoAnnouncer plugin, List<String> messages) {
+    public AnnouncementTask(AutoAnnouncer plugin, String prefix, List<String> messages) {
         this.plugin = plugin;
+        this.prefix = prefix;
         this.messages = messages;
     }
 
@@ -24,8 +26,11 @@ public class AnnouncementTask extends BukkitRunnable {
         // Get the current message
         String message = messages.get(messageIndex);
 
+        // Combine prefix and message, then colorize the whole thing
+        String finalMessage = prefix + message;
+
         // Broadcast the colorized message
-        plugin.getServer().broadcastMessage(AutoAnnouncer.colorize(message));
+        plugin.getServer().broadcastMessage(AutoAnnouncer.colorize(finalMessage));
 
         // Move to the next message for the next execution
         messageIndex++;

--- a/src/main/java/com/example/autoannouncer/AutoAnnouncer.java
+++ b/src/main/java/com/example/autoannouncer/AutoAnnouncer.java
@@ -4,10 +4,13 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.ChatColor;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class AutoAnnouncer extends JavaPlugin {
 
     private BukkitTask announcementTask;
+    private static final Pattern HEX_PATTERN = Pattern.compile("&#([A-Fa-f0-9]{6})");
 
     @Override
     public void onEnable() {
@@ -15,6 +18,7 @@ public class AutoAnnouncer extends JavaPlugin {
         saveDefaultConfig();
 
         // Load configuration
+        String prefix = getConfig().getString("prefix", "&d[Minekarta] &r");
         int interval = getConfig().getInt("interval", 60);
         List<String> messages = getConfig().getStringList("messages");
 
@@ -32,7 +36,7 @@ public class AutoAnnouncer extends JavaPlugin {
         // Schedule the announcement task
         // The period is in ticks (20 ticks = 1 second)
         long period = interval * 20L;
-        announcementTask = new AnnouncementTask(this, messages).runTaskTimer(this, 0L, period);
+        announcementTask = new AnnouncementTask(this, prefix, messages).runTaskTimer(this, 0L, period);
 
         getLogger().info("AutoAnnouncer has been enabled with " + messages.size() + " messages, running every " + interval + " seconds.");
     }
@@ -46,8 +50,23 @@ public class AutoAnnouncer extends JavaPlugin {
         getLogger().info("AutoAnnouncer has been disabled.");
     }
 
-    // Helper method to translate color codes
+    // Helper method to translate color codes, now with hex support
     public static String colorize(String message) {
-        return ChatColor.translateAlternateColorCodes('&', message);
+        if (message == null) {
+            return "";
+        }
+
+        Matcher matcher = HEX_PATTERN.matcher(message);
+        StringBuffer buffer = new StringBuffer();
+
+        while (matcher.find()) {
+            // Using Bukkit's ChatColor.of for modern versions (1.16+)
+            // This requires the server to be on a version that supports it.
+            // Spigot API bundles the necessary classes from BungeeCord.
+            matcher.appendReplacement(buffer, net.md_5.bungee.api.ChatColor.of("#" + matcher.group(1)).toString());
+        }
+        matcher.appendTail(buffer);
+
+        return ChatColor.translateAlternateColorCodes('&', buffer.toString());
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,12 +1,16 @@
 # Configuration for AutoAnnouncer
 
+# The prefix to be displayed before every announcement.
+# Default: "&d[Minekarta] &r"
+prefix: "&d[Minekarta] &r"
+
 # The interval in seconds between each announcement.
 interval: 60
 
 # The list of messages to be broadcast.
 # You can add as many messages as you want.
-# Color codes using '&' are supported.
+# Legacy color codes (&a, &b, etc.) and hex colors (&#RRGGBB) are supported.
 messages:
   - "&aWelcome to our server! We hope you have a great time."
   - "&bMake sure to read the /rules."
-  - "&eDid you know you can vote for our server to get rewards? Use /vote!"
+  - "&#4287f5Did you know you can vote for our server to get rewards? Use /vote!"


### PR DESCRIPTION
This commit adds two new features based on your feedback:
- Hex color support: The `colorize` method can now parse `&#RRGGBB` color codes, allowing for a full range of colors in messages and the prefix.
- Configurable prefix: A `prefix` option has been added to `config.yml`. This prefix is automatically prepended to every announcement.